### PR TITLE
修改merchant_key为merchant_pem

### DIFF
--- a/app/Http/Controllers/Pay/PaysapiController.php
+++ b/app/Http/Controllers/Pay/PaysapiController.php
@@ -82,7 +82,7 @@ class PaysapiController extends PayController
             return 'fail';
         }
         $payInfo = Pays::where('id', $cacheord['pay_way'])->first();
-        $temps = md5($data['orderid'] . $data['orderuid'] . $data['paysapi_id'] . $data['price'] . $data['realprice'] . $payInfo['merchant_key']);
+        $temps = md5($data['orderid'] . $data['orderuid'] . $data['paysapi_id'] . $data['price'] . $data['realprice'] . $payInfo['merchant_pem']);
         if ($temps != $data['key']){
             return 'fail';
         }else{


### PR DESCRIPTION
Fixes #72 

根据paysapi官方文档：https://www.paysapi.com/docpay
$payInfo['merchant_key']应该改为$payInfo['merchant_pem']
我在自己的网站上测试过了，改之后，Paysapi支付接口就能正常使用了。