### PR TITLE
调整订单标题格式

### DIFF
--- a/app/Service/OrderProcessService.php
+++ b/app/Service/OrderProcessService.php
@@ -315,7 +315,7 @@ class OrderProcessService
             // 设置商品
             $order->goods_id = $this->goods->id;
             // 标题
-            $order->title = $this->goods->gd_name . 'x' . $this->buyAmount;
+            $order->title = $this->goods->gd_name . ' x ' . $this->buyAmount;
             // 订单类型
             $order->type = $this->goods->type;
             // 查询密码


### PR DESCRIPTION
目前以英文结尾的商品生成的订单标题会类似于 `GoodsNamex3`，看起来很奇怪

给订单标题中的 `x` 前后加空格，把格式调整为类似于 `GoodsName x 12`