### PR TITLE
后台增加邮件测试、卡密支持循环、增加Google翻译、避免恶意刷单

### DIFF
--- a/app/Admin/Controllers/CarmisController.php
+++ b/app/Admin/Controllers/CarmisController.php
@@ -31,6 +31,7 @@ class CarmisController extends AdminController
             $grid->column('id')->sortable();
             $grid->column('goods.gd_name', admin_trans('carmis.fields.goods_id'));
             $grid->column('status')->select(CarmisModel::getStatusMap());
+            $grid->column('is_loop')->display(function($v){return $v==1?admin_trans('carmis.fields.yes'):"";});
             $grid->column('carmi')->limit(20);
             $grid->column('created_at');
             $grid->column('updated_at')->sortable();
@@ -75,6 +76,7 @@ class CarmisController extends AdminController
                     return admin_trans('carmis.fields.status_sold');
                 }
             });
+			$show->field('is_loop')->as(function ($v) {return $v==1?admin_trans('carmis.fields.yes'):"";});
             $show->field('carmi');
             $show->field('created_at');
             $show->field('updated_at');
@@ -96,6 +98,7 @@ class CarmisController extends AdminController
             $form->radio('status')
                 ->options(CarmisModel::getStatusMap())
                 ->default(CarmisModel::STATUS_UNSOLD);
+            $form->switch('is_loop')->default(false);
             $form->textarea('carmi')->required();
             $form->display('created_at');
             $form->display('updated_at');

--- a/app/Admin/Controllers/EmailTestController.php
+++ b/app/Admin/Controllers/EmailTestController.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * The file was created by Assimon.
+ *
+ * @author    ZhangYiQiu<me@zhangyiqiu.net>
+ * @copyright ZhangYiQiu<me@zhangyiqiu.net>
+ * @link      http://zhangyiqiu.net/
+ */
+
+namespace App\Admin\Controllers;
+
+
+use App\Admin\Forms\EmailTest;
+use Dcat\Admin\Http\Controllers\AdminController;
+use Dcat\Admin\Layout\Content;
+use Dcat\Admin\Widgets\Card;
+
+class EmailTestController extends AdminController
+{
+
+    /**
+     * 系统设置
+     *
+     * @param Content $content
+     * @return Content
+     *
+     * @author    assimon<ashang@utf8.hk>
+     * @copyright assimon<ashang@utf8.hk>
+     * @link      http://utf8.hk/
+     */
+    public function emailTest(Content $content)
+    {
+        return $content
+            ->title(admin_trans('menu.titles.email_test'))
+            ->body(new Card(new EmailTest()));
+    }
+
+}

--- a/app/Admin/Forms/EmailTest.php
+++ b/app/Admin/Forms/EmailTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * The file was created by Assimon.
+ *
+ * @author    ZhangYiQiu<me@zhangyiqiu.net>
+ * @copyright ZhangYiQiu<me@zhangyiqiu.net>
+ * @link      http://zhangyiqiu.net/
+ */
+
+namespace App\Admin\Forms;
+
+use App\Models\BaseModel;
+use Dcat\Admin\Widgets\Form;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Mail\MailServiceProvider;
+use Illuminate\Support\Facades\Mail;
+
+class EmailTest extends Form
+{
+    /**
+     * Handle the form request.
+     *
+     * @param array $input
+     *
+     * @return mixed
+     */
+    public function handle(array $input)
+    {
+      $to = $input['to'];
+      $title = $input['title'];
+      $body = $input['body'];
+      $sysConfig = cache('system-setting');
+      $mailConfig = [
+          'driver' => $sysConfig['driver'] ?? 'stmp',
+          'host' => $sysConfig['host'] ?? '',
+          'port' => $sysConfig['port'] ?? '465',
+          'username' => $sysConfig['username'] ?? '',
+          'from'      =>  [
+              'address'   =>   $sysConfig['from_address'] ?? '',
+              'name'      =>  $sysConfig['from_name'] ?? '独角发卡'
+          ],
+          'password' => $sysConfig['password'] ?? '',
+          'encryption' => $sysConfig['encryption'] ?? 'ssl'
+      ];
+      //  覆盖 mail 配置
+      config([
+          'mail'  =>  array_merge(config('mail'), $mailConfig)
+      ]);
+      // 重新注册驱动
+      (new MailServiceProvider(app()))->register();
+	  try
+	  {
+		  Mail::send(['html' => 'email.mail'], ['body' => $body], function ($message) use ($to, $title){
+			  $message->to($to)->subject($title);
+		  });
+	  }
+	  catch(\Exception $e)
+	  {
+		  return $this
+					->response()
+					->error($e->getMessage());
+	  }
+      return $this
+				->response()
+				->success(admin_trans('email-test.labels.success'));
+    }
+
+    /**
+     * Build a form here.
+     */
+    public function form()
+    {
+        $this->tab(admin_trans('menu.titles.email_test'), function () {
+            $this->text('to', admin_trans('email-test.labels.to'))->required();
+            $this->text('title', admin_trans('email-test.labels.title'))->default('这是一条测试邮件')->required();
+            $this->editor('body', admin_trans('email-test.labels.body'))->default("这是一条测试邮件的正文内容<br/><br/>正文比较长<br/><br/>非常长<br/><br/>测试测试测试")->required();
+        });
+    }
+
+    public function default()
+    {
+      
+    }
+
+}

--- a/app/Admin/Forms/SystemSetting.php
+++ b/app/Admin/Forms/SystemSetting.php
@@ -50,6 +50,8 @@ class SystemSetting extends Form
                 ->default(BaseModel::STATUS_CLOSE);
             $this->switch('is_open_search_pwd', admin_trans('system-setting.fields.is_open_search_pwd'))
                 ->default(BaseModel::STATUS_CLOSE);
+            $this->switch('is_open_google_translate', admin_trans('system-setting.fields.is_open_google_translate'))
+                ->default(BaseModel::STATUS_CLOSE);
             $this->editor('notice', admin_trans('system-setting.fields.notice'));
             $this->textarea('footer', admin_trans('system-setting.fields.footer'));
         });

--- a/app/Admin/routes.php
+++ b/app/Admin/routes.php
@@ -21,4 +21,5 @@ Route::group([
     $router->resource('order', 'OrderController');
     $router->get('import-carmis', 'CarmisController@importCarmis');
     $router->get('system-setting', 'SystemSettingController@systemSetting');
+    $router->get('email-test', 'EmailTestController@emailTest');
 });

--- a/app/Http/Controllers/Home/OrderController.php
+++ b/app/Http/Controllers/Home/OrderController.php
@@ -60,6 +60,7 @@ class OrderController extends BaseController
         try {
             $this->orderService->validatorCreateOrder($request);
             $goods = $this->orderService->validatorGoods($request);
+            $this->orderService->validatorLoopCarmis($request);
             // 设置商品
             $this->orderProcessService->setGoods($goods);
             // 优惠码

--- a/app/Service/CarmisService.php
+++ b/app/Service/CarmisService.php
@@ -48,7 +48,7 @@ class CarmisService
      */
     public function soldByIDS(array $ids): bool
     {
-        return Carmis::query()->whereIn('id', $ids)->update(['status' => Carmis::STATUS_SOLD]);
+        return Carmis::query()->whereIn('id', $ids)->where('is_loop', 0)->update(['status' => Carmis::STATUS_SOLD]);
     }
 
 }

--- a/app/Service/OrderService.php
+++ b/app/Service/OrderService.php
@@ -14,6 +14,7 @@ use App\Exceptions\RuleValidationException;
 use App\Models\BaseModel;
 use App\Models\Coupon;
 use App\Models\Goods;
+use App\Models\Carmis;
 use App\Models\Order;
 use App\Rules\SearchPwd;
 use App\Rules\VerifyImg;
@@ -114,6 +115,29 @@ class OrderService
             throw new RuleValidationException(__('dujiaoka.prompt.inventory_shortage'));
         }
         return $goods;
+    }
+	
+    /**
+     * 判断是否有循环卡密
+     *
+     * @param int $goodsID 商品id
+     * @return array|null
+     *
+     * @author    ZhangYiQiu<me@zhangyiqiu.net>
+     * @copyright ZhangYiQiu<me@zhangyiqiu.net>
+     * @link      http://zhangyiqiu.net/
+     */
+    public function validatorLoopCarmis(Request $request)
+    {
+        $carmis = Carmis::query()
+            ->where('goods_id', $request->input('gid'))
+            ->where('status', Carmis::STATUS_UNSOLD)
+            ->where('is_loop', true)
+            ->get();
+        if($carmis != null && $request->input('by_amount') > 1){
+			throw new RuleValidationException(__('dujiaoka.prompt.loop_carmis_limit'));
+		}
+		return $carmis;
     }
 
     /**

--- a/app/Service/OrderService.php
+++ b/app/Service/OrderService.php
@@ -61,11 +61,12 @@ class OrderService
             'email' => ['required', 'email'],
             'payway' => ['required', 'integer'],
             'search_pwd' => [new SearchPwd()],
-            'by_amount' => ['required', 'integer'],
+            'by_amount' => ['required', 'integer', 'min:1'],
             'img_verify_code' => [new VerifyImg()],
         ], [
             'by_amount.required' =>  __('dujiaoka.prompt.buy_amount_format_error'),
             'by_amount.integer' =>  __('dujiaoka.prompt.buy_amount_format_error'),
+            'by_amount.min' =>  __('dujiaoka.prompt.buy_amount_format_error'),
             'payway.required' =>  __('dujiaoka.prompt.please_select_mode_of_payment'),
             'payway.integer' =>  __('dujiaoka.prompt.please_select_mode_of_payment'),
             'email.required' =>  __('dujiaoka.prompt.email_format_error'),

--- a/app/Service/OrderService.php
+++ b/app/Service/OrderService.php
@@ -133,8 +133,8 @@ class OrderService
             ->where('goods_id', $request->input('gid'))
             ->where('status', Carmis::STATUS_UNSOLD)
             ->where('is_loop', true)
-            ->get();
-        if($carmis != null && $request->input('by_amount') > 1){
+            ->count();
+        if($carmis > 0 && $request->input('by_amount') > 1){
 			throw new RuleValidationException(__('dujiaoka.prompt.loop_carmis_limit'));
 		}
 		return $carmis;

--- a/database/sql/install.sql
+++ b/database/sql/install.sql
@@ -222,7 +222,7 @@ CREATE TABLE `carmis` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `goods_id` int NOT NULL COMMENT '所属商品',
   `status` tinyint(1) NOT NULL DEFAULT '1' COMMENT '状态 1未售出 2已售出',
-  `is_loop` tinyint(1) NOT NULL DEFAULT '1' COMMENT '循环卡密 1是 2否',
+  `is_loop` tinyint(1) NOT NULL DEFAULT '0' COMMENT '循环卡密 1是 0否',
   `carmi` text CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL COMMENT '卡密',
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,

--- a/database/sql/install.sql
+++ b/database/sql/install.sql
@@ -44,6 +44,8 @@ INSERT INTO `admin_menu` VALUES (21, 19, 19, 'Pay_Configuration', 'fa-cc-visa', 
 INSERT INTO `admin_menu` VALUES (22, 0, 8, 'Order_Manage', 'fa-table', NULL, '', 1, '2021-05-23 20:43:43', '2021-05-23 20:44:20');
 INSERT INTO `admin_menu` VALUES (23, 22, 20, 'Order', 'fa-heart', '/order', '', 1, '2021-05-23 20:46:13', '2021-05-23 20:47:16');
 INSERT INTO `admin_menu` VALUES (24, 19, 21, 'System_Setting', 'fa-cogs', '/system-setting', '', 1, '2021-05-26 10:26:34', '2021-05-26 10:26:34');
+INSERT INTO `admin_menu` VALUES (25, 19, 22, 'Email_Test', 'fa-envelope', '/email-test', '', 1, '2022-07-26 12:09:34', '2022-07-26 12:17:21');
+
 COMMIT;
 
 -- ----------------------------
@@ -220,6 +222,7 @@ CREATE TABLE `carmis` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `goods_id` int NOT NULL COMMENT '所属商品',
   `status` tinyint(1) NOT NULL DEFAULT '1' COMMENT '状态 1未售出 2已售出',
+  `is_loop` tinyint(1) NOT NULL DEFAULT '1' COMMENT '循环卡密 1是 2否',
   `carmi` text CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL COMMENT '卡密',
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,

--- a/resources/lang/zh_CN/carmis.php
+++ b/resources/lang/zh_CN/carmis.php
@@ -11,6 +11,8 @@ return [
         'carmi' => '卡密内容',
         'status_unsold' => '未售出',
         'status_sold' => '已售出',
+        'is_loop' => '循环卡密',
+		'yes'=>'是',
         'import_carmis' => '导入卡密',
         'carmis_list' => '卡密列表',
         'carmis_txt' => '卡密文本',

--- a/resources/lang/zh_CN/dujiaoka.php
+++ b/resources/lang/zh_CN/dujiaoka.php
@@ -123,7 +123,8 @@ return [
         'search_order_browser_tips' => '最多只能查询最近 5 笔订单',
         'no_related_order_found_for_cache' => '未找到相关订单缓存！',
         'no_related_order_found' => '未找到相关订单！',
-        'new_order_push' => '新订单通知'
+        'new_order_push' => '新订单通知',
+        'loop_carmis_limit' => '此商品最多购买一件！'
     ],
 
     'equipment' => [

--- a/resources/lang/zh_CN/email-test.php
+++ b/resources/lang/zh_CN/email-test.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * The file was created by Assimon.
+ *
+ * @author    ZhangYiQiu<me@zhangyiqiu.net>
+ * @copyright ZhangYiQiu<me@zhangyiqiu.net>
+ * @link      http://zhangyiqiu.net/
+ */
+
+return [
+    'labels' => [
+        'success' => '发送成功',
+        'to' => '收件人',
+        'title' => '邮件标题',
+        'body' => '邮件内容',
+    ],
+
+    'fields' => [
+        
+    ],
+    'options' => [
+    ],
+    'rule_messages' => [
+    ]
+];

--- a/resources/lang/zh_CN/menu.php
+++ b/resources/lang/zh_CN/menu.php
@@ -27,6 +27,7 @@ return [
         'pay_configuration'  => '支付配置',
         'order_manage' => '销售数据',
         'order'        => '订单列表',
-        'system_setting' => '系统设置'
+        'system_setting' => '系统设置',
+        'email_test' => '邮件测试'
     ],
 ];

--- a/resources/lang/zh_CN/system-setting.php
+++ b/resources/lang/zh_CN/system-setting.php
@@ -29,6 +29,7 @@ return [
         'is_open_anti_red' => '是否开启微信/QQ防红',
         'is_open_img_code' => '是否开启图形验证码',
         'is_open_search_pwd' => '是否开启查询密码',
+        'is_open_google_translate' => '是否开启google翻译',
         'is_open_server_jiang' => '是否开启server酱',
         'server_jiang_token' => 'server酱通讯token',
         'is_open_telegram_push' => '是否开启Telegram推送',

--- a/resources/lang/zh_TW/carmis.php
+++ b/resources/lang/zh_TW/carmis.php
@@ -11,6 +11,8 @@ return [
         'carmi' => '卡密內容',
         'status_unsold' => '未售出',
         'status_sold' => '已售出',
+        'is_loop' => '循環卡密',
+		'yes'=>'是',
         'import_carmis' => '匯入卡密',
         'carmis_list' => '卡密清單',
         'carmis_txt' => '卡密文字',

--- a/resources/views/luna/layouts/_header.blade.php
+++ b/resources/views/luna/layouts/_header.blade.php
@@ -11,3 +11,6 @@
         <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     @endif
 </head>
+@if(dujiaoka_config_get('is_open_google_translate') == \App\Models\BaseModel::STATUS_OPEN)
+@include('luna.layouts.google_translate')
+@endif

--- a/resources/views/luna/layouts/google_translate.php
+++ b/resources/views/luna/layouts/google_translate.php
@@ -1,0 +1,28 @@
+<div id="google_translate_element"></div>
+<style>
+#google_translate_element{
+	text-align: right;
+	position: fixed;
+    top: 40px;
+    right: 20px;
+    z-index: 1;
+}
+#google_translate_element select{
+	width: 8rem;
+}
+.goog-te-banner-content{
+	font-size: 0px!important;
+}
+.goog-logo-link{
+	display:none !important;
+}
+.goog-te-gadget{
+	color:transparent!important;
+}
+</style>
+<script type="text/Javascript">
+    function googleTranslateElementInit() {
+        new google.translate.TranslateElement({pageLanguage: 'zh', includedLanguages:'zh-TW,en,ru,fr'}, 'google_translate_element');
+    } 
+</script>
+<script type="text/Javascript" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>


### PR DESCRIPTION
1. 后台增加邮件测试，方便检测邮箱配置问题
2. 卡密支持循环
3. 增加Google翻译，仅修改了luna模板，其它模板可参考修改_header.blade.php页面
4. 避免提交负数购买数量恶意刷单