### PR TITLE
Fix error on Admin goods detail page

### DIFF
--- a/app/Admin/Controllers/GoodsController.php
+++ b/app/Admin/Controllers/GoodsController.php
@@ -92,8 +92,8 @@ class GoodsController extends AdminController
         return Show::make($id, new Goods(), function (Show $show) {
             $show->id('id');
             $show->field('gd_name');
-            $form->field('gd_description');
-            $form->field('gd_keywords');
+            $show->field('gd_description');
+            $show->field('gd_keywords');
             $show->field('picture')->image();
             $show->field('retail_price');
             $show->field('actual_price');


### PR DESCRIPTION
Fix the error when show goods detail on the admin page

The original error seems like below:

![Snipaste_2022-09-08_15-09-20](https://user-images.githubusercontent.com/16562294/189060059-da40ff39-9ba7-4fd3-bf2f-2847c3f654b7.jpg)