### PR TITLE
fix dujiaoka version mistake.

### DIFF
--- a/config/dujiaoka.php
+++ b/config/dujiaoka.php
@@ -8,7 +8,7 @@
  */
 
 return [
-    'dujiaoka_version' => '2.0.5',
+    'dujiaoka_version' => '2.0.6',
     // 模板集合
     'templates' => [
         'unicorn' => '官方[unicorn-独角兽]',


### PR DESCRIPTION
the latest dujiaoka version is 2.0.6,but when i run the latest version, i login into the admin,and see the brand
is still 2.0.5, here is the pic:
![image](https://user-images.githubusercontent.com/14249262/234597334-780b1cdd-2788-43f8-b144-97cfc645da4f.png)
so i fix this tiny mistake.