### PR TITLE
修复https下全新安装报错的bug

### DIFF
--- a/resources/views/common/install.blade.php
+++ b/resources/views/common/install.blade.php
@@ -778,7 +778,7 @@ TkSuQmCC" />
                         .text('安装中...')
                         .prop('disabled', true);
                     var adminurl = $("input[name='admin_path']").val()
-                    $.post('{{ url('/do-install') }}', $(this).serialize())
+                    $.post('/do-install', $(this).serialize())
                         .done(function (ret) {
                             if (ret === 'success') {
                                 $('#error').hide();


### PR DESCRIPTION
大量用户在使用宝塔等工具安装独脚数卡时，开启了https，因浏览器安全策略，不允许https页面发起http请求，无法完成安装。